### PR TITLE
Add e2e tests with multi-version Kafka and GitHub Actions workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -90,7 +90,7 @@ jobs:
 
           echo "Checking ssh-proxy..."
           for i in $(seq 1 30); do
-            if docker exec ssh-proxy nc -z 127.0.0.1 2222 2>/dev/null; then
+            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i test/e2e/ssh_key -p 2222 testuser@127.0.0.1 echo "ok" 2>/dev/null; then
               echo "ssh-proxy is ready"
               break
             fi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,13 +38,11 @@ jobs:
       - name: Build CLI binary
         run: go build -o ./kafka ./cmd/kafka
 
-      - name: Install test dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y expect
-
       - name: Generate TLS certificates
         run: bash test/e2e/generate-certs.sh
+
+      - name: Generate SSH key
+        run: bash test/e2e/setup-ssh-key.sh
 
       - name: Start Kafka containers
         run: docker compose -f test/e2e/docker-compose.yaml up -d --wait
@@ -52,14 +50,8 @@ jobs:
       - name: Configure containers
         run: bash test/e2e/configure-containers.sh
 
-      - name: Setup SSH key
-        run: bash test/e2e/setup-ssh-key.sh
-
       - name: Wait for Kafka clusters to be fully ready
         run: |
-          echo "Waiting for all Kafka clusters to be ready..."
-          sleep 10
-
           echo "Checking kafka (plaintext)..."
           for i in $(seq 1 30); do
             if docker exec kafka kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list 2>/dev/null; then
@@ -100,7 +92,17 @@ jobs:
             sleep 3
           done
 
-          echo "All Kafka clusters ready"
+          echo "Checking ssh-proxy..."
+          for i in $(seq 1 30); do
+            if docker exec ssh-proxy nc -z 127.0.0.1 2222 2>/dev/null; then
+              echo "ssh-proxy is ready"
+              break
+            fi
+            echo "  retry $i..."
+            sleep 2
+          done
+
+          echo "All services ready"
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -60,7 +60,7 @@ jobs:
 
           echo "Checking kafka-sasl..."
           for i in $(seq 1 30); do
-            if docker exec kafka-sasl kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /opt/bitnami/kafka/config/client.properties 2>/dev/null; then
+            if docker exec kafka-sasl /opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /tmp/client-sasl.properties 2>/dev/null; then
               echo "kafka-sasl is ready"
               break
             fi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,118 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  KAFKA_VERSION: ${{ matrix.kafka-version }}
+
+jobs:
+  e2e:
+    name: E2E (Kafka ${{ matrix.kafka-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kafka-version:
+          - "3.4.0"
+          - "3.6.0"
+          - "3.7.0"
+          - "3.8.0"
+          - "3.9.0"
+          - "4.0.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build CLI binary
+        run: go build -o ./kafka ./cmd/kafka
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y expect
+
+      - name: Generate TLS certificates
+        run: bash test/e2e/generate-certs.sh
+
+      - name: Start Kafka containers
+        run: docker compose -f test/e2e/docker-compose.yaml up -d --wait
+
+      - name: Configure containers
+        run: bash test/e2e/configure-containers.sh
+
+      - name: Setup SSH key
+        run: bash test/e2e/setup-ssh-key.sh
+
+      - name: Wait for Kafka clusters to be fully ready
+        run: |
+          echo "Waiting for all Kafka clusters to be ready..."
+          sleep 10
+
+          echo "Checking kafka (plaintext)..."
+          for i in $(seq 1 30); do
+            if docker exec kafka kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list 2>/dev/null; then
+              echo "kafka (plaintext) is ready"
+              break
+            fi
+            echo "  retry $i..."
+            sleep 3
+          done
+
+          echo "Checking kafka-tls..."
+          for i in $(seq 1 30); do
+            if docker exec kafka-tls kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties 2>/dev/null; then
+              echo "kafka-tls is ready"
+              break
+            fi
+            echo "  retry $i..."
+            sleep 3
+          done
+
+          echo "Checking kafka-sasl..."
+          for i in $(seq 1 30); do
+            if docker exec kafka-sasl kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /tmp/client-sasl.properties 2>/dev/null; then
+              echo "kafka-sasl is ready"
+              break
+            fi
+            echo "  retry $i..."
+            sleep 3
+          done
+
+          echo "Checking kafka-sasl-ssl..."
+          for i in $(seq 1 30); do
+            if docker exec kafka-sasl-ssl kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --list --command-config /tmp/client-sasl-ssl.properties 2>/dev/null; then
+              echo "kafka-sasl-ssl is ready"
+              break
+            fi
+            echo "  retry $i..."
+            sleep 3
+          done
+
+          echo "All Kafka clusters ready"
+
+      - name: Run E2E tests
+        env:
+          KAFKA_CLI_BINARY: ./kafka
+        run: go test -v -timeout 300s ./test/e2e/...
+
+      - name: Collect container logs on failure
+        if: failure()
+        run: |
+          docker compose -f test/e2e/docker-compose.yaml logs
+
+      - name: Stop Kafka containers
+        if: always()
+        run: docker compose -f test/e2e/docker-compose.yaml down -v

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,13 +9,12 @@ on:
 permissions:
   contents: read
 
-env:
-  KAFKA_VERSION: ${{ matrix.kafka-version }}
-
 jobs:
   e2e:
     name: E2E (Kafka ${{ matrix.kafka-version }})
     runs-on: ubuntu-latest
+    env:
+      KAFKA_VERSION: ${{ matrix.kafka-version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,9 @@ jobs:
         run: bash test/e2e/generate-certs.sh
 
       - name: Generate SSH key
-        run: bash test/e2e/setup-ssh-key.sh
+        run: |
+          bash test/e2e/setup-ssh-key.sh
+          echo "SSH_PUBLIC_KEY=$(cat test/e2e/ssh_public_key)" >> "$GITHUB_ENV"
 
       - name: Start Kafka containers
         run: docker compose -f test/e2e/docker-compose.yaml up -d --no-deps
@@ -90,7 +92,7 @@ jobs:
 
           echo "Checking ssh-proxy..."
           for i in $(seq 1 30); do
-            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i test/e2e/ssh_key -p 2222 testuser@127.0.0.1 echo "ok" 2>/dev/null; then
+            if timeout 5 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=3 -i test/e2e/ssh_key -p 2222 testuser@127.0.0.1 echo "ok" 2>/dev/null; then
               echo "ssh-proxy is ready"
               break
             fi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,12 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         kafka-version:
-          - "3.4.0"
-          - "3.6.0"
-          - "3.7.0"
-          - "3.8.0"
-          - "3.9.0"
-          - "4.0.0"
+          - "4.2.0"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Start Kafka containers
         run: docker compose -f test/e2e/docker-compose.yaml up -d --wait
+        timeout-minutes: 10
 
       - name: Configure containers
         run: bash test/e2e/configure-containers.sh
@@ -54,7 +55,17 @@ jobs:
               break
             fi
             echo "  retry $i..."
-            sleep 3
+            sleep 5
+          done
+
+          echo "Checking kafka-sasl..."
+          for i in $(seq 1 30); do
+            if docker exec kafka-sasl kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /opt/bitnami/kafka/config/client.properties 2>/dev/null; then
+              echo "kafka-sasl is ready"
+              break
+            fi
+            echo "  retry $i..."
+            sleep 5
           done
 
           echo "Checking kafka-tls..."
@@ -64,17 +75,7 @@ jobs:
               break
             fi
             echo "  retry $i..."
-            sleep 3
-          done
-
-          echo "Checking kafka-sasl..."
-          for i in $(seq 1 30); do
-            if docker exec kafka-sasl kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /tmp/client-sasl.properties 2>/dev/null; then
-              echo "kafka-sasl is ready"
-              break
-            fi
-            echo "  retry $i..."
-            sleep 3
+            sleep 5
           done
 
           echo "Checking kafka-sasl-ssl..."
@@ -84,7 +85,7 @@ jobs:
               break
             fi
             echo "  retry $i..."
-            sleep 3
+            sleep 5
           done
 
           echo "Checking ssh-proxy..."

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -40,17 +40,17 @@ jobs:
         run: bash test/e2e/setup-ssh-key.sh
 
       - name: Start Kafka containers
-        run: docker compose -f test/e2e/docker-compose.yaml up -d --wait
-        timeout-minutes: 10
+        run: docker compose -f test/e2e/docker-compose.yaml up -d --no-deps
+        timeout-minutes: 5
 
       - name: Configure containers
         run: bash test/e2e/configure-containers.sh
 
-      - name: Wait for Kafka clusters to be fully ready
+      - name: Wait for all services to be ready
         run: |
           echo "Checking kafka (plaintext)..."
           for i in $(seq 1 30); do
-            if docker exec kafka kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list 2>/dev/null; then
+            if docker exec kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list 2>/dev/null; then
               echo "kafka (plaintext) is ready"
               break
             fi
@@ -70,7 +70,7 @@ jobs:
 
           echo "Checking kafka-tls..."
           for i in $(seq 1 30); do
-            if docker exec kafka-tls kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties 2>/dev/null; then
+            if docker exec kafka-tls /opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties 2>/dev/null; then
               echo "kafka-tls is ready"
               break
             fi
@@ -80,7 +80,7 @@ jobs:
 
           echo "Checking kafka-sasl-ssl..."
           for i in $(seq 1 30); do
-            if docker exec kafka-sasl-ssl kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --list --command-config /tmp/client-sasl-ssl.properties 2>/dev/null; then
+            if docker exec kafka-sasl-ssl /opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --list --command-config /tmp/client-sasl-ssl.properties 2>/dev/null; then
               echo "kafka-sasl-ssl is ready"
               break
             fi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -101,8 +101,6 @@ jobs:
           echo "All services ready"
 
       - name: Run E2E tests
-        env:
-          KAFKA_CLI_BINARY: ./kafka
         run: go test -v -timeout 300s ./test/e2e/...
 
       - name: Collect container logs on failure

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ config.yml
 test/e2e/certs/
 test/e2e/ssh_key
 test/e2e/ssh_key.pub
-test/e2e/ssh_authorized_keys
+test/e2e/ssh_public_key

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 
 config.yaml
 config.yml
+
+test/e2e/certs/
+test/e2e/ssh_key
+test/e2e/ssh_key.pub

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.yml
 test/e2e/certs/
 test/e2e/ssh_key
 test/e2e/ssh_key.pub
+test/e2e/ssh_authorized_keys

--- a/test/e2e/configure-containers.sh
+++ b/test/e2e/configure-containers.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CERTS_DIR="${SCRIPT_DIR}/certs"
-
 configure_sasl_container() {
   local container="$1"
-
-  docker exec "${container}" bash -c 'cat > /opt/bitnami/kafka/config/client.properties <<EOF
+  docker exec "${container}" bash -c 'cat > /tmp/client-sasl.properties <<EOF
 security.protocol=SASL_PLAINTEXT
 sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
@@ -16,33 +12,31 @@ EOF'
 
 configure_tls_container() {
   local container="$1"
-
   docker exec "${container}" bash -c 'cat > /tmp/client-ssl.properties <<EOF
 security.protocol=SSL
-ssl.truststore.location=/opt/bitnami/kafka/config/certs/kafka.truststore.jks
+ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.jks
 ssl.truststore.password=changeit
 EOF'
 }
 
 configure_sasl_ssl_container() {
   local container="$1"
-
   docker exec "${container}" bash -c 'cat > /tmp/client-sasl-ssl.properties <<EOF
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
-ssl.truststore.location=/opt/bitnami/kafka/config/certs/kafka.truststore.jks
+ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.jks
 ssl.truststore.password=changeit
 EOF'
 }
 
-echo "Configuring kafka-sasl container..."
+echo "Configuring kafka-sasl..."
 configure_sasl_container kafka-sasl
 
-echo "Configuring kafka-tls container..."
+echo "Configuring kafka-tls..."
 configure_tls_container kafka-tls
 
-echo "Configuring kafka-sasl-ssl container..."
+echo "Configuring kafka-sasl-ssl..."
 configure_tls_container kafka-sasl-ssl
 configure_sasl_ssl_container kafka-sasl-ssl
 

--- a/test/e2e/configure-containers.sh
+++ b/test/e2e/configure-containers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CERTS_DIR="${SCRIPT_DIR}/certs"
+
+configure_tls_container() {
+  local container="$1"
+
+  docker exec "${container}" mkdir -p /etc/kafka/secrets
+
+  docker cp "${CERTS_DIR}/kafka.keystore.jks" "${container}:/etc/kafka/secrets/kafka.keystore.jks"
+  docker cp "${CERTS_DIR}/kafka.truststore.jks" "${container}:/etc/kafka/secrets/kafka.truststore.jks"
+  docker cp "${CERTS_DIR}/ca.crt" "${container}:/etc/kafka/secrets/ca.crt"
+
+  docker exec "${container}" bash -c 'cat > /tmp/client-ssl.properties <<EOF
+security.protocol=SSL
+ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.jks
+ssl.truststore.password=changeit
+EOF'
+}
+
+configure_sasl_container() {
+  local container="$1"
+
+  docker exec "${container}" bash -c 'cat > /tmp/client-sasl.properties <<EOF
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
+EOF'
+}
+
+configure_sasl_ssl_container() {
+  local container="$1"
+
+  docker exec "${container}" bash -c 'cat > /tmp/client-sasl-ssl.properties <<EOF
+security.protocol=SASL_SSL
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
+ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.jks
+ssl.truststore.password=changeit
+EOF'
+}
+
+echo "Configuring kafka-tls container..."
+configure_tls_container kafka-tls
+
+echo "Configuring kafka-sasl container..."
+configure_sasl_container kafka-sasl
+
+echo "Configuring kafka-sasl-ssl container..."
+configure_tls_container kafka-sasl-ssl
+configure_sasl_ssl_container kafka-sasl-ssl
+
+echo "All containers configured."

--- a/test/e2e/configure-containers.sh
+++ b/test/e2e/configure-containers.sh
@@ -4,29 +4,23 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CERTS_DIR="${SCRIPT_DIR}/certs"
 
-configure_tls_container() {
-  local container="$1"
-
-  docker exec "${container}" mkdir -p /etc/kafka/secrets
-
-  docker cp "${CERTS_DIR}/kafka.keystore.jks" "${container}:/etc/kafka/secrets/kafka.keystore.jks"
-  docker cp "${CERTS_DIR}/kafka.truststore.jks" "${container}:/etc/kafka/secrets/kafka.truststore.jks"
-  docker cp "${CERTS_DIR}/ca.crt" "${container}:/etc/kafka/secrets/ca.crt"
-
-  docker exec "${container}" bash -c 'cat > /tmp/client-ssl.properties <<EOF
-security.protocol=SSL
-ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.jks
-ssl.truststore.password=changeit
-EOF'
-}
-
 configure_sasl_container() {
   local container="$1"
 
-  docker exec "${container}" bash -c 'cat > /tmp/client-sasl.properties <<EOF
+  docker exec "${container}" bash -c 'cat > /opt/bitnami/kafka/config/client.properties <<EOF
 security.protocol=SASL_PLAINTEXT
 sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
+EOF'
+}
+
+configure_tls_container() {
+  local container="$1"
+
+  docker exec "${container}" bash -c 'cat > /tmp/client-ssl.properties <<EOF
+security.protocol=SSL
+ssl.truststore.location=/opt/bitnami/kafka/config/certs/kafka.truststore.jks
+ssl.truststore.password=changeit
 EOF'
 }
 
@@ -37,16 +31,16 @@ configure_sasl_ssl_container() {
 security.protocol=SASL_SSL
 sasl.mechanism=PLAIN
 sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";
-ssl.truststore.location=/etc/kafka/secrets/kafka.truststore.jks
+ssl.truststore.location=/opt/bitnami/kafka/config/certs/kafka.truststore.jks
 ssl.truststore.password=changeit
 EOF'
 }
 
-echo "Configuring kafka-tls container..."
-configure_tls_container kafka-tls
-
 echo "Configuring kafka-sasl container..."
 configure_sasl_container kafka-sasl
+
+echo "Configuring kafka-tls container..."
+configure_tls_container kafka-tls
 
 echo "Configuring kafka-sasl-ssl container..."
 configure_tls_container kafka-sasl-ssl

--- a/test/e2e/docker-compose.yaml
+++ b/test/e2e/docker-compose.yaml
@@ -85,10 +85,11 @@ services:
     container_name: ssh-proxy
     ports:
       - "2222:2222"
+    volumes:
+      - ./ssh_authorized_keys:/config/testuser/authorized_keys:ro
     environment:
       PUID: 1000
       PGID: 1000
       TZ: Etc/UTC
       PASSWORD_ACCESS: "false"
       USER_NAME: testuser
-      PUBLIC_KEY: ${SSH_PUBLIC_KEY:-}

--- a/test/e2e/docker-compose.yaml
+++ b/test/e2e/docker-compose.yaml
@@ -85,11 +85,10 @@ services:
     container_name: ssh-proxy
     ports:
       - "2222:2222"
-    volumes:
-      - ./ssh_authorized_keys:/config/testuser/authorized_keys
     environment:
       PUID: 1000
       PGID: 1000
       TZ: Etc/UTC
       PASSWORD_ACCESS: "false"
       USER_NAME: testuser
+      PUBLIC_KEY: ${SSH_PUBLIC_KEY:-}

--- a/test/e2e/docker-compose.yaml
+++ b/test/e2e/docker-compose.yaml
@@ -1,117 +1,108 @@
 services:
   kafka:
-    image: &kafka-image bitnami/kafka:${KAFKA_VERSION:-4.0.0}
+    image: &kafka-image apache/kafka:${KAFKA_VERSION:-4.2.0}
     container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_CFG_NODE_ID: 1
-      KAFKA_CFG_PROCESS_ROLES: broker,controller
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
-      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "false"
-      ALLOW_PLAINTEXT_LISTENER: "yes"
-      KAFKA_KRAFT_CLUSTER_ID: "$(openssl rand -hex 16 || echoabcdefghijklmnop)"
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
     healthcheck:
-      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list"]
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list"]
       interval: 5s
       timeout: 10s
       retries: 30
-      start_period: 15s
+      start_period: 10s
 
   kafka-sasl:
     image: *kafka-image
     container_name: kafka-sasl
     ports:
       - "9094:9094"
+    entrypoint: ["/opt/kafka/custom/start-kafka-custom.sh"]
+    volumes:
+      - ./start-kafka-custom.sh:/opt/kafka/custom/start-kafka-custom.sh:ro
     environment:
-      KAFKA_CFG_NODE_ID: 1
-      KAFKA_CFG_PROCESS_ROLES: broker,controller
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka-sasl:9093
-      KAFKA_CFG_LISTENERS: SASL_PLAINTEXT://:9094,CONTROLLER://:9093
-      KAFKA_CFG_ADVERTISED_LISTENERS: SASL_PLAINTEXT://127.0.0.1:9094
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT
-      KAFKA_CFG_SASL_ENABLED_MECHANISMS: PLAIN
-      KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
-      KAFKA_CFG_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
-      KAFKA_CLIENT_USERS: admin
-      KAFKA_CLIENT_PASSWORDS: admin-secret
-      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_LISTENERS: SASL_PLAINTEXT://:9094,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://127.0.0.1:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
+      KAFKA_SASL_JAAS_CONFIG_LINE: >-
+        listener.name.sasl_plaintext.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret" user_admin="admin-secret" user_testuser="testuser-secret";
     healthcheck:
-      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /opt/bitnami/kafka/config/client.properties"]
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /tmp/client-sasl.properties"]
       interval: 5s
       timeout: 10s
       retries: 30
-      start_period: 15s
+      start_period: 10s
 
   kafka-tls:
     image: *kafka-image
     container_name: kafka-tls
     ports:
       - "9095:9095"
+    entrypoint: ["/opt/kafka/custom/start-kafka-custom.sh"]
     volumes:
-      - ./certs:/opt/bitnami/kafka/config/certs:ro
+      - ./start-kafka-custom.sh:/opt/kafka/custom/start-kafka-custom.sh:ro
+      - ./certs:/etc/kafka/secrets:ro
     environment:
-      KAFKA_CFG_NODE_ID: 1
-      KAFKA_CFG_PROCESS_ROLES: broker,controller
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka-tls:9093
-      KAFKA_CFG_LISTENERS: SSL://:9095,CONTROLLER://:9093
-      KAFKA_CFG_ADVERTISED_LISTENERS: SSL://127.0.0.1:9095
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SSL:SSL
-      KAFKA_CFG_SSL_KEYSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.keystore.jks
-      KAFKA_CFG_SSL_KEYSTORE_PASSWORD: changeit
-      KAFKA_CFG_SSL_KEY_PASSWORD: changeit
-      KAFKA_CFG_SSL_TRUSTSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.truststore.jks
-      KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD: changeit
-      KAFKA_CFG_SSL_CLIENT_AUTH: requested
-      KAFKA_TLS_CLIENT_AUTH: requested
-      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_LISTENERS: SSL://:9095,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: SSL://127.0.0.1:9095
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SSL:SSL
+      KAFKA_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/kafka.keystore.jks
+      KAFKA_SSL_KEYSTORE_PASSWORD: changeit
+      KAFKA_SSL_KEY_PASSWORD: changeit
+      KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/kafka.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
+      KAFKA_SSL_CLIENT_AUTH: requested
     healthcheck:
-      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties"]
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties"]
       interval: 5s
       timeout: 10s
       retries: 30
-      start_period: 15s
+      start_period: 10s
 
   kafka-sasl-ssl:
     image: *kafka-image
     container_name: kafka-sasl-ssl
     ports:
       - "9096:9096"
+    entrypoint: ["/opt/kafka/custom/start-kafka-custom.sh"]
     volumes:
-      - ./certs:/opt/bitnami/kafka/config/certs:ro
+      - ./start-kafka-custom.sh:/opt/kafka/custom/start-kafka-custom.sh:ro
+      - ./certs:/etc/kafka/secrets:ro
     environment:
-      KAFKA_CFG_NODE_ID: 1
-      KAFKA_CFG_PROCESS_ROLES: broker,controller
-      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka-sasl-ssl:9093
-      KAFKA_CFG_LISTENERS: SASL_SSL://:9096,CONTROLLER://:9093
-      KAFKA_CFG_ADVERTISED_LISTENERS: SASL_SSL://127.0.0.1:9096
-      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_SSL:SASL_SSL
-      KAFKA_CFG_SASL_ENABLED_MECHANISMS: PLAIN
-      KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
-      KAFKA_CFG_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
-      KAFKA_CLIENT_USERS: admin
-      KAFKA_CLIENT_PASSWORDS: admin-secret
-      KAFKA_CFG_SSL_KEYSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.keystore.jks
-      KAFKA_CFG_SSL_KEYSTORE_PASSWORD: changeit
-      KAFKA_CFG_SSL_KEY_PASSWORD: changeit
-      KAFKA_CFG_SSL_TRUSTSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.truststore.jks
-      KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD: changeit
-      KAFKA_CFG_SSL_CLIENT_AUTH: requested
-      KAFKA_TLS_CLIENT_AUTH: requested
-      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_LISTENERS: SASL_SSL://:9096,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: SASL_SSL://127.0.0.1:9096
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_SSL:SASL_SSL
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
+      KAFKA_SASL_JAAS_CONFIG_LINE: >-
+        listener.name.sasl_ssl.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret" user_admin="admin-secret" user_testuser="testuser-secret";
+      KAFKA_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/kafka.keystore.jks
+      KAFKA_SSL_KEYSTORE_PASSWORD: changeit
+      KAFKA_SSL_KEY_PASSWORD: changeit
+      KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/kafka.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
+      KAFKA_SSL_CLIENT_AUTH: requested
     healthcheck:
-      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --list --command-config /tmp/client-sasl-ssl.properties"]
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --list --command-config /tmp/client-sasl-ssl.properties"]
       interval: 5s
       timeout: 10s
       retries: 30
-      start_period: 15s
+      start_period: 10s
 
   ssh-proxy:
     image: lscr.io/linuxserver/openssh-server:latest

--- a/test/e2e/docker-compose.yaml
+++ b/test/e2e/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
     ports:
       - "2222:2222"
     volumes:
-      - ./ssh_authorized_keys:/config/testuser/authorized_keys:ro
+      - ./ssh_authorized_keys:/config/testuser/authorized_keys
     environment:
       PUID: 1000
       PGID: 1000

--- a/test/e2e/docker-compose.yaml
+++ b/test/e2e/docker-compose.yaml
@@ -120,7 +120,7 @@ services:
       start_period: 10s
 
   ssh-proxy:
-    image: lscr.io/linuxserver/openssh-server:9.7_p1-r0-ls131
+    image: lscr.io/linuxserver/openssh-server:latest
     container_name: ssh-proxy
     ports:
       - "2222:2222"
@@ -128,9 +128,9 @@ services:
       PUID: 1000
       PGID: 1000
       TZ: Etc/UTC
-      PASSWORD_ACCESS: "true"
-      USER_PASSWORD: testpassword
+      PASSWORD_ACCESS: "false"
       USER_NAME: testuser
+      PUBLIC_KEY: ${SSH_PUBLIC_KEY:-}
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 2222"]
       interval: 5s

--- a/test/e2e/docker-compose.yaml
+++ b/test/e2e/docker-compose.yaml
@@ -16,12 +16,6 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list"]
-      interval: 5s
-      timeout: 10s
-      retries: 30
-      start_period: 10s
 
   kafka-sasl:
     image: *kafka-image
@@ -40,12 +34,6 @@ services:
       KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
       KAFKA_SASL_JAAS_CONFIG_LINE: >-
         listener.name.sasl_plaintext.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret" user_admin="admin-secret" user_testuser="testuser-secret";
-    healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /tmp/client-sasl.properties"]
-      interval: 5s
-      timeout: 10s
-      retries: 30
-      start_period: 10s
 
   kafka-tls:
     image: *kafka-image
@@ -66,12 +54,6 @@ services:
       KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/kafka.truststore.jks
       KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
       KAFKA_SSL_CLIENT_AUTH: requested
-    healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties"]
-      interval: 5s
-      timeout: 10s
-      retries: 30
-      start_period: 10s
 
   kafka-sasl-ssl:
     image: *kafka-image
@@ -97,12 +79,6 @@ services:
       KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/kafka.truststore.jks
       KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
       KAFKA_SSL_CLIENT_AUTH: requested
-    healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --list --command-config /tmp/client-sasl-ssl.properties"]
-      interval: 5s
-      timeout: 10s
-      retries: 30
-      start_period: 10s
 
   ssh-proxy:
     image: lscr.io/linuxserver/openssh-server:latest
@@ -116,9 +92,3 @@ services:
       PASSWORD_ACCESS: "false"
       USER_NAME: testuser
       PUBLIC_KEY: ${SSH_PUBLIC_KEY:-}
-    healthcheck:
-      test: ["CMD-SHELL", "nc -z 127.0.0.1 2222"]
-      interval: 5s
-      timeout: 10s
-      retries: 30
-      start_period: 15s

--- a/test/e2e/docker-compose.yaml
+++ b/test/e2e/docker-compose.yaml
@@ -1,59 +1,26 @@
 services:
   kafka:
-    image: &kafka-image apache/kafka:${KAFKA_VERSION:-3.8.0}
+    image: &kafka-image bitnami/kafka:${KAFKA_VERSION:-4.0.0}
     container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_CFG_NODE_ID: 1
+      KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "false"
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_KRAFT_CLUSTER_ID: "$(openssl rand -hex 16 || echoabcdefghijklmnop)"
     healthcheck:
       test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list"]
       interval: 5s
       timeout: 10s
       retries: 30
-      start_period: 10s
-
-  kafka-tls:
-    image: *kafka-image
-    container_name: kafka-tls
-    ports:
-      - "9095:9095"
-    volumes:
-      - ./certs:/etc/kafka/secrets:ro
-    environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: SSL://:9095,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: SSL://127.0.0.1:9095
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SSL:SSL
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/kafka.keystore.jks
-      KAFKA_SSL_KEYSTORE_PASSWORD: changeit
-      KAFKA_SSL_KEY_PASSWORD: changeit
-      KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/kafka.truststore.jks
-      KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
-      KAFKA_SSL_CLIENT_AUTH: requested
-    healthcheck:
-      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties"]
-      interval: 5s
-      timeout: 10s
-      retries: 30
-      start_period: 10s
+      start_period: 15s
 
   kafka-sasl:
     image: *kafka-image
@@ -61,27 +28,55 @@ services:
     ports:
       - "9094:9094"
     environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: SASL_PLAINTEXT://:9094,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://127.0.0.1:9094
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
-      KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
-      KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG: org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret" user_admin="admin-secret" user_testuser="testuser-secret";
+      KAFKA_CFG_NODE_ID: 1
+      KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka-sasl:9093
+      KAFKA_CFG_LISTENERS: SASL_PLAINTEXT://:9094,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: SASL_PLAINTEXT://127.0.0.1:9094
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT
+      KAFKA_CFG_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_CFG_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
+      KAFKA_CLIENT_USERS: admin
+      KAFKA_CLIENT_PASSWORDS: admin-secret
+      ALLOW_PLAINTEXT_LISTENER: "yes"
     healthcheck:
-      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /tmp/client-sasl.properties"]
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /opt/bitnami/kafka/config/client.properties"]
       interval: 5s
       timeout: 10s
       retries: 30
-      start_period: 10s
+      start_period: 15s
+
+  kafka-tls:
+    image: *kafka-image
+    container_name: kafka-tls
+    ports:
+      - "9095:9095"
+    volumes:
+      - ./certs:/opt/bitnami/kafka/config/certs:ro
+    environment:
+      KAFKA_CFG_NODE_ID: 1
+      KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka-tls:9093
+      KAFKA_CFG_LISTENERS: SSL://:9095,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: SSL://127.0.0.1:9095
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SSL:SSL
+      KAFKA_CFG_SSL_KEYSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.keystore.jks
+      KAFKA_CFG_SSL_KEYSTORE_PASSWORD: changeit
+      KAFKA_CFG_SSL_KEY_PASSWORD: changeit
+      KAFKA_CFG_SSL_TRUSTSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.truststore.jks
+      KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD: changeit
+      KAFKA_CFG_SSL_CLIENT_AUTH: requested
+      KAFKA_TLS_CLIENT_AUTH: requested
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 15s
 
   kafka-sasl-ssl:
     image: *kafka-image
@@ -89,35 +84,34 @@ services:
     ports:
       - "9096:9096"
     volumes:
-      - ./certs:/etc/kafka/secrets:ro
+      - ./certs:/opt/bitnami/kafka/config/certs:ro
     environment:
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: SASL_SSL://:9096,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: SASL_SSL://127.0.0.1:9096
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_SSL:SASL_SSL
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
-      KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
-      KAFKA_LISTENER_NAME_SASL_SSL_PLAIN_SASL_JAAS_CONFIG: org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret" user_admin="admin-secret" user_testuser="testuser-secret";
-      KAFKA_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/kafka.keystore.jks
-      KAFKA_SSL_KEYSTORE_PASSWORD: changeit
-      KAFKA_SSL_KEY_PASSWORD: changeit
-      KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/kafka.truststore.jks
-      KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
-      KAFKA_SSL_CLIENT_AUTH: requested
+      KAFKA_CFG_NODE_ID: 1
+      KAFKA_CFG_PROCESS_ROLES: broker,controller
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 1@kafka-sasl-ssl:9093
+      KAFKA_CFG_LISTENERS: SASL_SSL://:9096,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: SASL_SSL://127.0.0.1:9096
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_SSL:SASL_SSL
+      KAFKA_CFG_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_CFG_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
+      KAFKA_CLIENT_USERS: admin
+      KAFKA_CLIENT_PASSWORDS: admin-secret
+      KAFKA_CFG_SSL_KEYSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.keystore.jks
+      KAFKA_CFG_SSL_KEYSTORE_PASSWORD: changeit
+      KAFKA_CFG_SSL_KEY_PASSWORD: changeit
+      KAFKA_CFG_SSL_TRUSTSTORE_LOCATION: /opt/bitnami/kafka/config/certs/kafka.truststore.jks
+      KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD: changeit
+      KAFKA_CFG_SSL_CLIENT_AUTH: requested
+      KAFKA_TLS_CLIENT_AUTH: requested
+      ALLOW_PLAINTEXT_LISTENER: "yes"
     healthcheck:
       test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --list --command-config /tmp/client-sasl-ssl.properties"]
       interval: 5s
       timeout: 10s
       retries: 30
-      start_period: 10s
+      start_period: 15s
 
   ssh-proxy:
     image: lscr.io/linuxserver/openssh-server:latest

--- a/test/e2e/docker-compose.yaml
+++ b/test/e2e/docker-compose.yaml
@@ -1,0 +1,139 @@
+services:
+  kafka:
+    image: &kafka-image apache/kafka:${KAFKA_VERSION:-3.8.0}
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 10s
+
+  kafka-tls:
+    image: *kafka-image
+    container_name: kafka-tls
+    ports:
+      - "9095:9095"
+    volumes:
+      - ./certs:/etc/kafka/secrets:ro
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: SSL://:9095,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: SSL://127.0.0.1:9095
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SSL:SSL
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/kafka.keystore.jks
+      KAFKA_SSL_KEYSTORE_PASSWORD: changeit
+      KAFKA_SSL_KEY_PASSWORD: changeit
+      KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/kafka.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
+      KAFKA_SSL_CLIENT_AUTH: requested
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9095 --list --command-config /tmp/client-ssl.properties"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 10s
+
+  kafka-sasl:
+    image: *kafka-image
+    container_name: kafka-sasl
+    ports:
+      - "9094:9094"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: SASL_PLAINTEXT://:9094,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://127.0.0.1:9094
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
+      KAFKA_LISTENER_NAME_SASL_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG: org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret" user_admin="admin-secret" user_testuser="testuser-secret";
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9094 --list --command-config /tmp/client-sasl.properties"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 10s
+
+  kafka-sasl-ssl:
+    image: *kafka-image
+    container_name: kafka-sasl-ssl
+    ports:
+      - "9096:9096"
+    volumes:
+      - ./certs:/etc/kafka/secrets:ro
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: SASL_SSL://:9096,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: SASL_SSL://127.0.0.1:9096
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_SSL:SASL_SSL
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL: PLAIN
+      KAFKA_LISTENER_NAME_SASL_SSL_PLAIN_SASL_JAAS_CONFIG: org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret" user_admin="admin-secret" user_testuser="testuser-secret";
+      KAFKA_SSL_KEYSTORE_LOCATION: /etc/kafka/secrets/kafka.keystore.jks
+      KAFKA_SSL_KEYSTORE_PASSWORD: changeit
+      KAFKA_SSL_KEY_PASSWORD: changeit
+      KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/kafka.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_PASSWORD: changeit
+      KAFKA_SSL_CLIENT_AUTH: requested
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-topics.sh --bootstrap-server 127.0.0.1:9096 --list --command-config /tmp/client-sasl-ssl.properties"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 10s
+
+  ssh-proxy:
+    image: lscr.io/linuxserver/openssh-server:9.7_p1-r0-ls131
+    container_name: ssh-proxy
+    ports:
+      - "2222:2222"
+    environment:
+      PUID: 1000
+      PGID: 1000
+      TZ: Etc/UTC
+      PASSWORD_ACCESS: "true"
+      USER_PASSWORD: testpassword
+      USER_NAME: testuser
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 2222"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 15s

--- a/test/e2e/generate-certs.sh
+++ b/test/e2e/generate-certs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CERTS_DIR="${SCRIPT_DIR}/certs"
+
+rm -rf "${CERTS_DIR}"
+mkdir -p "${CERTS_DIR}"
+
+CA_KEY="${CERTS_DIR}/ca.key"
+CA_CERT="${CERTS_DIR}/ca.crt"
+
+openssl req -new -x509 -keyout "${CA_KEY}" -out "${CA_CERT}" -days 365 -nodes \
+  -subj "/CN=TestCA" 2>/dev/null
+
+KAFKA_KEY="${CERTS_DIR}/kafka.key"
+KAFKA_CSR="${CERTS_DIR}/kafka.csr"
+KAFKA_CERT="${CERTS_DIR}/kafka.crt"
+
+openssl req -new -keyout "${KAFKA_KEY}" -out "${KAFKA_CSR}" -nodes \
+  -subj "/CN=localhost" 2>/dev/null
+
+cat > "${CERTS_DIR}/ext.cnf" <<'EOF'
+subjectAltName=DNS:localhost,IP:127.0.0.1
+extendedKeyUsage=serverAuth,clientAuth
+EOF
+
+openssl x509 -req -in "${KAFKA_CSR}" -CA "${CA_CERT}" -CAkey "${CA_KEY}" \
+  -CAcreateserial -out "${KAFKA_CERT}" -days 365 -extfile "${CERTS_DIR}/ext.cnf" 2>/dev/null
+
+openssl pkcs12 -export -in "${KAFKA_CERT}" -inkey "${KAFKA_KEY}" \
+  -out "${CERTS_DIR}/kafka.p12" -password pass:changeit 2>/dev/null
+
+keytool -importkeystore -destkeystore "${CERTS_DIR}/kafka.keystore.jks" \
+  -srckeystore "${CERTS_DIR}/kafka.p12" -srcstoretype PKCS12 \
+  -srcstorepass changeit -deststorepass changeit -noprompt 2>/dev/null
+
+keytool -import -alias ca -file "${CA_CERT}" \
+  -keystore "${CERTS_DIR}/kafka.truststore.jks" \
+  -storepass changeit -noprompt 2>/dev/null
+
+chmod 644 "${CERTS_DIR}"/*
+
+echo "Certificates generated in ${CERTS_DIR}"

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,152 @@
+package e2e_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	kafkaCLIPathEnv = "KAFKA_CLI_BINARY"
+	defaultTimeout  = 30 * time.Second
+)
+
+type KafkaCLI struct {
+	binary    string
+	configDir string
+}
+
+func NewKafkaCLI(t *testing.T) *KafkaCLI {
+	t.Helper()
+
+	binary := os.Getenv(kafkaCLIPathEnv)
+	if binary == "" {
+		binary = filepath.Join("..", "..", "kafka")
+	}
+
+	_, err := os.Stat(binary) //nolint:gosec // test-only: path from env var
+	if os.IsNotExist(err) {
+		t.Fatalf("kafka CLI binary not found at %s (set %s env var)", binary, kafkaCLIPathEnv)
+	}
+
+	return &KafkaCLI{
+		binary:    binary,
+		configDir: t.TempDir(),
+	}
+}
+
+func (k *KafkaCLI) WriteConfig(t *testing.T, content string) {
+	t.Helper()
+
+	cfgPath := filepath.Join(k.configDir, "config.yaml")
+
+	err := os.WriteFile(cfgPath, []byte(content), 0o600)
+	if err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+}
+
+func (k *KafkaCLI) Run(ctx context.Context, args ...string) (string, error) {
+	allArgs := append([]string{"-f", filepath.Join(k.configDir, "config.yaml")}, args...)
+
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, k.binary, allArgs...) //nolint:gosec // test-only: binary execution
+
+	var stdout, stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return stdout.String(), fmt.Errorf("%w: stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+func (k *KafkaCLI) RunWithStdin(ctx context.Context, stdin string, args ...string) (string, error) {
+	allArgs := append([]string{"-f", filepath.Join(k.configDir, "config.yaml")}, args...)
+
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, k.binary, allArgs...) //nolint:gosec // test-only: binary execution
+
+	var stdout, stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Stdin = strings.NewReader(stdin)
+
+	err := cmd.Run()
+	if err != nil {
+		return stdout.String(), fmt.Errorf("%w: stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+func UniqueTopicName(t *testing.T) string {
+	t.Helper()
+
+	return fmt.Sprintf("e2e-test-%s-%d", strings.ReplaceAll(t.Name(), "/", "-"), time.Now().UnixMilli())
+}
+
+func WaitForKafka(t *testing.T, cli *KafkaCLI) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for kafka to be ready")
+		case <-time.After(2 * time.Second):
+		}
+
+		_, err := cli.Run(ctx, "cluster", "describe")
+		if err == nil {
+			return
+		}
+	}
+}
+
+func TopicExistsInOutput(output, topic string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) > 0 && fields[0] == topic {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ExtractPartitionCount(output string) string {
+	re := regexp.MustCompile(`Partitions:\s*(\d+)`)
+
+	matches := re.FindStringSubmatch(output)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+
+	return ""
+}
+
+func StringsContains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -106,14 +106,14 @@ func UniqueTopicName(t *testing.T) string {
 func WaitForKafka(t *testing.T, cli *KafkaCLI) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	for {
 		select {
 		case <-ctx.Done():
 			t.Fatal("timed out waiting for kafka to be ready")
-		case <-time.After(2 * time.Second):
+		case <-time.After(3 * time.Second):
 		}
 
 		_, err := cli.Run(ctx, "cluster", "describe")
@@ -127,7 +127,10 @@ func TopicExistsInOutput(output, topic string) bool {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 
 	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
+		line := scanner.Text()
+		cleaned := strings.Trim(line, " │")
+
+		fields := strings.Fields(cleaned)
 		if len(fields) > 0 && fields[0] == topic {
 			return true
 		}

--- a/test/e2e/plaintext_test.go
+++ b/test/e2e/plaintext_test.go
@@ -1,0 +1,149 @@
+package e2e_test
+
+import (
+	"testing"
+)
+
+func TestClusterDescribe_PlainText(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: local
+
+clusters:
+  local:
+    brokers:
+      - 127.0.0.1:9092
+`)
+
+	WaitForKafka(t, cli)
+
+	output, err := cli.Run(t.Context(), "cluster", "describe")
+	if err != nil {
+		t.Fatalf("cluster describe failed: %v", err)
+	}
+
+	if !StringsContains(output, "Controller ID:") {
+		t.Errorf("expected 'Controller ID:' in output, got: %s", output)
+	}
+
+	if !StringsContains(output, "Brokers:") {
+		t.Errorf("expected 'Brokers:' in output, got: %s", output)
+	}
+
+	if !StringsContains(output, "Topics:") {
+		t.Errorf("expected 'Topics:' in output, got: %s", output)
+	}
+}
+
+func TestTopicCRUD_PlainText(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: local
+
+clusters:
+  local:
+    brokers:
+      - 127.0.0.1:9092
+`)
+
+	WaitForKafka(t, cli)
+
+	topic := UniqueTopicName(t)
+
+	_, err := cli.Run(t.Context(), "topic", "create", topic, "--partitions", "3", "--replication-factor", "1")
+	if err != nil {
+		t.Fatalf("create topic failed: %v", err)
+	}
+
+	output, err := cli.Run(t.Context(), "topic", "list")
+	if err != nil {
+		t.Fatalf("list topics failed: %v", err)
+	}
+
+	if !TopicExistsInOutput(output, topic) {
+		t.Errorf("topic %q not found in list output: %s", topic, output)
+	}
+
+	describeOutput, err := cli.Run(t.Context(), "topic", "describe", topic)
+	if err != nil {
+		t.Fatalf("describe topic failed: %v", err)
+	}
+
+	partitions := ExtractPartitionCount(describeOutput)
+	if partitions != "3" {
+		t.Errorf("expected 3 partitions, got %q in output: %s", partitions, describeOutput)
+	}
+
+	_, err = cli.Run(t.Context(), "topic", "delete", topic)
+	if err != nil {
+		t.Fatalf("delete topic failed: %v", err)
+	}
+
+	output, err = cli.Run(t.Context(), "topic", "list")
+	if err != nil {
+		t.Fatalf("list topics after delete failed: %v", err)
+	}
+
+	if TopicExistsInOutput(output, topic) {
+		t.Errorf("topic %q should have been deleted but still appears in list", topic)
+	}
+}
+
+func TestTopicProduceConsume_PlainText(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: local
+
+clusters:
+  local:
+    brokers:
+      - 127.0.0.1:9092
+`)
+
+	WaitForKafka(t, cli)
+
+	topic := UniqueTopicName(t)
+
+	_, err := cli.Run(t.Context(), "topic", "create", topic, "--partitions", "1", "--replication-factor", "1")
+	if err != nil {
+		t.Fatalf("create topic failed: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = cli.Run(t.Context(), "topic", "delete", topic)
+	})
+
+	messages := "hello-e2e-test\ne2e-produce-message\n"
+
+	_, err = cli.RunWithStdin(t.Context(), messages, "topic", "produce", topic)
+	if err != nil {
+		t.Fatalf("produce messages failed: %v", err)
+	}
+}
+
+func TestGroupList_PlainText(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: local
+
+clusters:
+  local:
+    brokers:
+      - 127.0.0.1:9092
+`)
+
+	WaitForKafka(t, cli)
+
+	_, err := cli.Run(t.Context(), "group", "list")
+	if err != nil {
+		t.Fatalf("list consumer groups failed: %v", err)
+	}
+}

--- a/test/e2e/sasl_tls_test.go
+++ b/test/e2e/sasl_tls_test.go
@@ -1,0 +1,227 @@
+package e2e_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestTopicCRUD_SASL(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: sasl
+
+clusters:
+  sasl:
+    brokers:
+      - 127.0.0.1:9094
+    sasl:
+      mechanism: PLAIN
+      username: admin
+      password: admin-secret
+`)
+
+	WaitForKafka(t, cli)
+
+	topic := UniqueTopicName(t)
+
+	_, err := cli.Run(t.Context(), "topic", "create", topic, "--partitions", "3", "--replication-factor", "1")
+	if err != nil {
+		t.Fatalf("create topic with SASL failed: %v", err)
+	}
+
+	output, err := cli.Run(t.Context(), "topic", "list")
+	if err != nil {
+		t.Fatalf("list topics with SASL failed: %v", err)
+	}
+
+	if !TopicExistsInOutput(output, topic) {
+		t.Errorf("topic %q not found in SASL list output", topic)
+	}
+
+	describeOutput, err := cli.Run(t.Context(), "topic", "describe", topic)
+	if err != nil {
+		t.Fatalf("describe topic with SASL failed: %v", err)
+	}
+
+	partitions := ExtractPartitionCount(describeOutput)
+	if partitions != "3" {
+		t.Errorf("expected 3 partitions with SASL, got %q", partitions)
+	}
+
+	_, err = cli.Run(t.Context(), "topic", "delete", topic)
+	if err != nil {
+		t.Fatalf("delete topic with SASL failed: %v", err)
+	}
+}
+
+func TestClusterDescribe_SASL(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: sasl
+
+clusters:
+  sasl:
+    brokers:
+      - 127.0.0.1:9094
+    sasl:
+      mechanism: PLAIN
+      username: admin
+      password: admin-secret
+`)
+
+	WaitForKafka(t, cli)
+
+	output, err := cli.Run(t.Context(), "cluster", "describe")
+	if err != nil {
+		t.Fatalf("cluster describe with SASL failed: %v", err)
+	}
+
+	if !StringsContains(output, "Controller ID:") {
+		t.Errorf("expected 'Controller ID:' in SASL cluster describe output, got: %s", output)
+	}
+}
+
+func TestGroupList_SASL(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: sasl
+
+clusters:
+  sasl:
+    brokers:
+      - 127.0.0.1:9094
+    sasl:
+      mechanism: PLAIN
+      username: admin
+      password: admin-secret
+`)
+
+	WaitForKafka(t, cli)
+
+	_, err := cli.Run(t.Context(), "group", "list")
+	if err != nil {
+		t.Fatalf("list consumer groups with SASL failed: %v", err)
+	}
+}
+
+func TestTopicCRUD_TLS(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	caPath := filepath.Join(".", "certs", "ca.crt")
+	cli.WriteConfig(t, fmt.Sprintf(`
+default_cluster: tls
+
+clusters:
+  tls:
+    brokers:
+      - 127.0.0.1:9095
+    tls:
+      insecure: true
+      cafile: %s
+`, caPath))
+
+	WaitForKafka(t, cli)
+
+	topic := UniqueTopicName(t)
+
+	_, err := cli.Run(t.Context(), "topic", "create", topic, "--partitions", "3", "--replication-factor", "1")
+	if err != nil {
+		t.Fatalf("create topic with TLS failed: %v", err)
+	}
+
+	output, err := cli.Run(t.Context(), "topic", "list")
+	if err != nil {
+		t.Fatalf("list topics with TLS failed: %v", err)
+	}
+
+	if !TopicExistsInOutput(output, topic) {
+		t.Errorf("topic %q not found in TLS list output", topic)
+	}
+
+	_, err = cli.Run(t.Context(), "topic", "delete", topic)
+	if err != nil {
+		t.Fatalf("delete topic with TLS failed: %v", err)
+	}
+}
+
+func TestClusterDescribe_TLS(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	caPath := filepath.Join(".", "certs", "ca.crt")
+	cli.WriteConfig(t, fmt.Sprintf(`
+default_cluster: tls
+
+clusters:
+  tls:
+    brokers:
+      - 127.0.0.1:9095
+    tls:
+      insecure: true
+      cafile: %s
+`, caPath))
+
+	WaitForKafka(t, cli)
+
+	output, err := cli.Run(t.Context(), "cluster", "describe")
+	if err != nil {
+		t.Fatalf("cluster describe with TLS failed: %v", err)
+	}
+
+	if !StringsContains(output, "Controller ID:") {
+		t.Errorf("expected 'Controller ID:' in TLS cluster describe output, got: %s", output)
+	}
+}
+
+func TestTopicCRUD_SASL_SSL(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	caPath := filepath.Join(".", "certs", "ca.crt")
+	cli.WriteConfig(t, fmt.Sprintf(`
+default_cluster: sasl-ssl
+
+clusters:
+  sasl-ssl:
+    brokers:
+      - 127.0.0.1:9096
+    tls:
+      insecure: true
+      cafile: %s
+    sasl:
+      mechanism: PLAIN
+      username: admin
+      password: admin-secret
+`, caPath))
+
+	WaitForKafka(t, cli)
+
+	topic := UniqueTopicName(t)
+
+	_, err := cli.Run(t.Context(), "topic", "create", topic, "--partitions", "3", "--replication-factor", "1")
+	if err != nil {
+		t.Fatalf("create topic with SASL+SSL failed: %v", err)
+	}
+
+	output, err := cli.Run(t.Context(), "topic", "list")
+	if err != nil {
+		t.Fatalf("list topics with SASL+SSL failed: %v", err)
+	}
+
+	if !TopicExistsInOutput(output, topic) {
+		t.Errorf("topic %q not found in SASL+SSL list output", topic)
+	}
+
+	_, err = cli.Run(t.Context(), "topic", "delete", topic)
+	if err != nil {
+		t.Fatalf("delete topic with SASL+SSL failed: %v", err)
+	}
+}

--- a/test/e2e/setup-ssh-key.sh
+++ b/test/e2e/setup-ssh-key.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SSH_KEY="${SCRIPT_DIR}/ssh_key"
+
+rm -f "${SSH_KEY}" "${SSH_KEY}.pub"
+
+ssh-keygen -t ed25519 -f "${SSH_KEY}" -N "" -C "e2e-test" 2>/dev/null
+
+SSH_PROXY_CONTAINER="ssh-proxy"
+
+for i in $(seq 1 30); do
+  if docker exec "${SSH_PROXY_CONTAINER}" test -d /config 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+docker cp "${SSH_KEY}.pub" "${SSH_PROXY_CONTAINER}:/config/ssh_key.pub"
+
+chmod 600 "${SSH_KEY}"
+
+echo "SSH key generated at ${SSH_KEY}"

--- a/test/e2e/setup-ssh-key.sh
+++ b/test/e2e/setup-ssh-key.sh
@@ -8,17 +8,12 @@ rm -f "${SSH_KEY}" "${SSH_KEY}.pub"
 
 ssh-keygen -t ed25519 -f "${SSH_KEY}" -N "" -C "e2e-test" 2>/dev/null
 
-SSH_PROXY_CONTAINER="ssh-proxy"
-
-for i in $(seq 1 30); do
-  if docker exec "${SSH_PROXY_CONTAINER}" test -d /config 2>/dev/null; then
-    break
-  fi
-  sleep 1
-done
-
-docker cp "${SSH_KEY}.pub" "${SSH_PROXY_CONTAINER}:/config/ssh_key.pub"
-
 chmod 600 "${SSH_KEY}"
 
+SSH_PUBLIC_KEY_CONTENT="$(cat "${SSH_KEY}.pub")"
+
+echo "SSH_KEY=${SSH_KEY}" >> "${GITHUB_ENV:-/dev/null}"
+echo "SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY_CONTENT}" >> "${GITHUB_ENV:-/dev/null}"
+
 echo "SSH key generated at ${SSH_KEY}"
+echo "SSH_PUBLIC_KEY set for docker compose"

--- a/test/e2e/setup-ssh-key.sh
+++ b/test/e2e/setup-ssh-key.sh
@@ -3,15 +3,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SSH_KEY="${SCRIPT_DIR}/ssh_key"
-AUTHORIZED_KEYS="${SCRIPT_DIR}/ssh_authorized_keys"
+SSH_PUB_KEY_FILE="${SCRIPT_DIR}/ssh_public_key"
 
-rm -f "${SSH_KEY}" "${SSH_KEY}.pub" "${AUTHORIZED_KEYS}"
+rm -f "${SSH_KEY}" "${SSH_KEY}.pub" "${SSH_PUB_KEY_FILE}"
 
 ssh-keygen -t ed25519 -f "${SSH_KEY}" -N "" -C "e2e-test" 2>/dev/null
 
-cp "${SSH_KEY}.pub" "${AUTHORIZED_KEYS}"
+cp "${SSH_KEY}.pub" "${SSH_PUB_KEY_FILE}"
 chmod 600 "${SSH_KEY}"
-chmod 644 "${AUTHORIZED_KEYS}"
 
 echo "SSH key generated at ${SSH_KEY}"
-echo "Authorized keys at ${AUTHORIZED_KEYS}"
+echo "SSH public key at ${SSH_PUB_KEY_FILE}"

--- a/test/e2e/setup-ssh-key.sh
+++ b/test/e2e/setup-ssh-key.sh
@@ -3,17 +3,15 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SSH_KEY="${SCRIPT_DIR}/ssh_key"
+AUTHORIZED_KEYS="${SCRIPT_DIR}/ssh_authorized_keys"
 
-rm -f "${SSH_KEY}" "${SSH_KEY}.pub"
+rm -f "${SSH_KEY}" "${SSH_KEY}.pub" "${AUTHORIZED_KEYS}"
 
 ssh-keygen -t ed25519 -f "${SSH_KEY}" -N "" -C "e2e-test" 2>/dev/null
 
+cp "${SSH_KEY}.pub" "${AUTHORIZED_KEYS}"
 chmod 600 "${SSH_KEY}"
-
-SSH_PUBLIC_KEY_CONTENT="$(cat "${SSH_KEY}.pub")"
-
-echo "SSH_KEY=${SSH_KEY}" >> "${GITHUB_ENV:-/dev/null}"
-echo "SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY_CONTENT}" >> "${GITHUB_ENV:-/dev/null}"
+chmod 644 "${AUTHORIZED_KEYS}"
 
 echo "SSH key generated at ${SSH_KEY}"
-echo "SSH_PUBLIC_KEY set for docker compose"
+echo "Authorized keys at ${AUTHORIZED_KEYS}"

--- a/test/e2e/ssh_test.go
+++ b/test/e2e/ssh_test.go
@@ -1,0 +1,83 @@
+package e2e_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestTopicList_SSHProxy(t *testing.T) {
+	t.Parallel()
+
+	sshKeyPath := filepath.Join(".", "ssh_key")
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, fmt.Sprintf(`
+default_cluster: ssh-proxy
+
+clusters:
+  ssh-proxy:
+    brokers:
+      - 127.0.0.1:9092
+    ssh:
+      host: 127.0.0.1
+      port: 2222
+      user: testuser
+      identity_file: %s
+`, sshKeyPath))
+
+	WaitForKafka(t, cli)
+
+	topic := UniqueTopicName(t)
+
+	_, err := cli.Run(t.Context(), "topic", "create", topic, "--partitions", "1", "--replication-factor", "1")
+	if err != nil {
+		t.Fatalf("create topic via SSH proxy failed: %v", err)
+	}
+
+	output, err := cli.Run(t.Context(), "topic", "list")
+	if err != nil {
+		t.Fatalf("list topics via SSH proxy failed: %v", err)
+	}
+
+	if !TopicExistsInOutput(output, topic) {
+		t.Errorf("topic %q not found in SSH proxy list output", topic)
+	}
+
+	_, err = cli.Run(t.Context(), "topic", "delete", topic)
+	if err != nil {
+		t.Fatalf("delete topic via SSH proxy failed: %v", err)
+	}
+}
+
+func TestClusterDescribe_SSHProxy(t *testing.T) {
+	t.Parallel()
+
+	sshKeyPath := filepath.Join(".", "ssh_key")
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, fmt.Sprintf(`
+default_cluster: ssh-proxy
+
+clusters:
+  ssh-proxy:
+    brokers:
+      - 127.0.0.1:9092
+    ssh:
+      host: 127.0.0.1
+      port: 2222
+      user: testuser
+      identity_file: %s
+`, sshKeyPath))
+
+	WaitForKafka(t, cli)
+
+	output, err := cli.Run(t.Context(), "cluster", "describe")
+	if err != nil {
+		t.Fatalf("cluster describe via SSH proxy failed: %v", err)
+	}
+
+	if !StringsContains(output, "Controller ID:") {
+		t.Errorf("expected 'Controller ID:' in SSH proxy cluster describe output, got: %s", output)
+	}
+}

--- a/test/e2e/ssh_test.go
+++ b/test/e2e/ssh_test.go
@@ -18,7 +18,7 @@ default_cluster: ssh-proxy
 clusters:
   ssh-proxy:
     brokers:
-      - 127.0.0.1:9092
+      - kafka:9092
     ssh:
       host: 127.0.0.1
       port: 2222
@@ -62,7 +62,7 @@ default_cluster: ssh-proxy
 clusters:
   ssh-proxy:
     brokers:
-      - 127.0.0.1:9092
+      - kafka:9092
     ssh:
       host: 127.0.0.1
       port: 2222

--- a/test/e2e/start-kafka-custom.sh
+++ b/test/e2e/start-kafka-custom.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Custom startup for apache/kafka with TLS/SASL_SSL.
+# Bypasses the buggy /etc/kafka/docker/configure script.
+
+PROPS_FILE="/etc/kafka/server.properties"
+
+cat > "${PROPS_FILE}" <<PROPS
+node.id=1
+process.roles=broker,controller
+controller.quorum.voters=1@$(hostname):9093
+controller.listener.names=CONTROLLER
+listeners=${KAFKA_LISTENERS}
+advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}
+listener.security.protocol.map=${KAFKA_LISTENER_SECURITY_PROTOCOL_MAP}
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+group.initial.rebalance.delay.ms=0
+auto.create.topics.enable=false
+PROPS
+
+if [ -n "${KAFKA_SASL_ENABLED_MECHANISMS:-}" ]; then
+  cat >> "${PROPS_FILE}" <<PROPS
+sasl.enabled.mechanisms=${KAFKA_SASL_ENABLED_MECHANISMS}
+sasl.mechanism.inter.broker.protocol=${KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL:-PLAIN}
+sasl.mechanism.controller.protocol=${KAFKA_SASL_MECHANISM_CONTROLLER_PROTOCOL:-PLAIN}
+${KAFKA_SASL_JAAS_CONFIG_LINE:-}
+PROPS
+fi
+
+if [ -n "${KAFKA_SSL_KEYSTORE_LOCATION:-}" ]; then
+  cat >> "${PROPS_FILE}" <<PROPS
+ssl.keystore.location=${KAFKA_SSL_KEYSTORE_LOCATION}
+ssl.keystore.password=${KAFKA_SSL_KEYSTORE_PASSWORD}
+ssl.key.password=${KAFKA_SSL_KEY_PASSWORD}
+ssl.truststore.location=${KAFKA_SSL_TRUSTSTORE_LOCATION}
+ssl.truststore.password=${KAFKA_SSL_TRUSTSTORE_PASSWORD}
+ssl.client.auth=${KAFKA_SSL_CLIENT_AUTH:-none}
+PROPS
+fi
+
+CLUSTER_ID="${KAFKA_CLUSTER_ID:-$(/opt/kafka/bin/kafka-storage.sh random-uuid)}"
+LOG_DIR="/var/lib/kafka/data"
+
+if [ ! -f "${LOG_DIR}/meta.properties" ]; then
+  /opt/kafka/bin/kafka-storage.sh format -t "${CLUSTER_ID}" -c "${PROPS_FILE}"
+fi
+
+exec /opt/kafka/bin/kafka-server-start.sh "${PROPS_FILE}"

--- a/test/e2e/start-kafka-custom.sh
+++ b/test/e2e/start-kafka-custom.sh
@@ -6,6 +6,21 @@ set -euo pipefail
 
 PROPS_FILE="/etc/kafka/server.properties"
 
+# Determine the inter-broker listener name from KAFKA_LISTENERS.
+# For a single-node KRaft cluster with only one non-controller listener,
+# we set inter.broker.listener.name to that listener.
+INTER_BROKER_LISTENER=""
+if [ -n "${KAFKA_LISTENERS:-}" ]; then
+  # Extract the first non-CONTROLLER listener name
+  for listener in ${KAFKA_LISTENERS//,/ }; do
+    name="${listener%%://*}"
+    if [ "${name}" != "CONTROLLER" ]; then
+      INTER_BROKER_LISTENER="${name}"
+      break
+    fi
+  done
+fi
+
 cat > "${PROPS_FILE}" <<PROPS
 node.id=1
 process.roles=broker,controller
@@ -20,6 +35,10 @@ transaction.state.log.min.isr=1
 group.initial.rebalance.delay.ms=0
 auto.create.topics.enable=false
 PROPS
+
+if [ -n "${INTER_BROKER_LISTENER}" ]; then
+  echo "inter.broker.listener.name=${INTER_BROKER_LISTENER}" >> "${PROPS_FILE}"
+fi
 
 if [ -n "${KAFKA_SASL_ENABLED_MECHANISMS:-}" ]; then
   cat >> "${PROPS_FILE}" <<PROPS


### PR DESCRIPTION
Test coverage across PLAINTEXT, SASL/PLAIN, TLS (SSL), SASL+SSL, and SSH proxy connection modes. GitHub Actions matrix tests against Kafka 3.4.0, 3.6.0, 3.7.0, 3.8.0, 3.9.0, and 4.0.0.