### PR TITLE
Add consumer group offsets and lag details

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,28 @@ kafka group list
 
 ### `kafka group describe GROUP`
 
-Show details of a consumer group (members, offsets, lag, etc.).
+Show details of a consumer group (state, protocol, members, etc.).
 
 ```shell
 kafka group describe my-group
+```
+
+### `kafka group offsets GROUP`
+
+Show committed offsets and partition lag for a consumer group. Use `--topic` to limit output to one topic.
+
+```shell
+kafka group offsets my-group
+kafka group offsets my-group --topic my-topic
+```
+
+### `kafka group lag GROUP`
+
+Show aggregated and partition-level lag for a consumer group. Use `--topic` to limit output to one topic.
+
+```shell
+kafka group lag my-group
+kafka group lag my-group --topic my-topic
 ```
 
 ### `kafka group delete GROUP [GROUP...]`

--- a/cmd/kafka/group.go
+++ b/cmd/kafka/group.go
@@ -17,6 +17,8 @@ func groupCmd() *cobra.Command {
 
 	cmd.AddCommand(groupListCmd())
 	cmd.AddCommand(groupDescribeCmd())
+	cmd.AddCommand(groupOffsetsCmd())
+	cmd.AddCommand(groupLagCmd())
 	cmd.AddCommand(groupDeleteCmd())
 
 	return cmd
@@ -82,6 +84,87 @@ func groupDescribeCmd() *cobra.Command {
 
 			return nil
 		},
+	}
+
+	return cmd
+}
+
+func groupOffsetsCmd() *cobra.Command {
+	return newGroupTopicCmd(
+		"offsets GROUP",
+		"Show committed offsets for a consumer group",
+		"Only show offsets for the specified topic",
+		func(admin *admin.Admin, group string, topic string) error {
+			err := admin.ListConsumerGroupOffsets(group, topic)
+			if err != nil {
+				return fmt.Errorf("admin.ListConsumerGroupOffsets error: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+func groupLagCmd() *cobra.Command {
+	return newGroupTopicCmd(
+		"lag GROUP",
+		"Show lag for a consumer group",
+		"Only show lag for the specified topic",
+		func(admin *admin.Admin, group string, topic string) error {
+			err := admin.ListConsumerGroupLag(group, topic)
+			if err != nil {
+				return fmt.Errorf("admin.ListConsumerGroupLag error: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+type groupTopicRunFunc func(admin *admin.Admin, group string, topic string) error
+
+func newGroupTopicCmd(
+	use string,
+	short string,
+	topicFlagUsage string,
+	run groupTopicRunFunc,
+) *cobra.Command {
+	var topic string
+
+	cmd := &cobra.Command{
+		Use:               use,
+		Short:             short,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: consumerGroupCompletionFunc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			kafkaAdmin, closer, err := admin.NewFromConfig(cfg, cluster)
+			if err != nil {
+				return fmt.Errorf("provideAdmin error: %w", err)
+			}
+
+			defer func() {
+				err := closer(ctx)
+				if err != nil {
+					slog.Error("closer error", slog.Any("error", err))
+				}
+			}()
+
+			err = run(kafkaAdmin, args[0], topic)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&topic, "topic", "", topicFlagUsage)
+
+	err := cmd.RegisterFlagCompletionFunc("topic", topicCompletionFunc)
+	if err != nil {
+		panic(fmt.Sprintf("RegisterFlagCompletionFunc error: %v", err))
 	}
 
 	return cmd

--- a/internal/kafka/admin/group.go
+++ b/internal/kafka/admin/group.go
@@ -50,24 +50,9 @@ func (a *Admin) ListConsumerGroups() error {
 }
 
 func (a *Admin) DescribeConsumerGroup(group string) error {
-	details, err := a.clusterAdmin.DescribeConsumerGroups([]string{group})
+	desc, err := a.describeConsumerGroup(group)
 	if err != nil {
-		return fmt.Errorf("clusterAdmin.DescribeConsumerGroups error: %w", err)
-	}
-
-	if len(details) == 0 {
-		return fmt.Errorf("%w: %s", errConsumerGroupNotFound, group)
-	}
-
-	desc := details[0]
-
-	if desc.State == "Dead" {
-		return fmt.Errorf("%w: %s", errConsumerGroupNotFound, group)
-	}
-
-	offsetResp, err := a.clusterAdmin.ListConsumerGroupOffsets(group, nil)
-	if err != nil {
-		return fmt.Errorf("clusterAdmin.ListConsumerGroupOffsets error: %w", err)
+		return err
 	}
 
 	fmt.Fprintf(os.Stdout, "Consumer Group: %s\n", desc.GroupId)
@@ -88,18 +73,126 @@ func (a *Admin) DescribeConsumerGroup(group string) error {
 		fmt.Fprintln(os.Stdout)
 	}
 
-	if len(offsetResp.Blocks) > 0 {
-		fmt.Fprintln(os.Stdout, "Offsets")
+	return nil
+}
 
-		assignments := a.buildPartitionAssignments(desc.Members)
-
-		err = a.renderGroupOffsetsTable(offsetResp.Blocks, assignments)
-		if err != nil {
-			return err
-		}
+func (a *Admin) describeConsumerGroup(group string) (*sarama.GroupDescription, error) {
+	details, err := a.clusterAdmin.DescribeConsumerGroups([]string{group})
+	if err != nil {
+		return nil, fmt.Errorf("clusterAdmin.DescribeConsumerGroups error: %w", err)
 	}
 
+	if len(details) == 0 || details[0].State == "Dead" {
+		return nil, fmt.Errorf("%w: %s", errConsumerGroupNotFound, group)
+	}
+
+	return details[0], nil
+}
+
+func (a *Admin) ListConsumerGroupOffsets(group string, topic string) error {
+	desc, offsetResp, partitionsByTopic, err := a.consumerGroupOffsets(group, topic)
+	if err != nil {
+		return err
+	}
+
+	partitions, endOffsets, err := a.buildGroupOffsetLookups(offsetResp.Blocks, partitionsByTopic)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "Consumer Group: %s\n", desc.GroupId)
+	fmt.Fprintln(os.Stdout)
+
+	assignments := a.buildPartitionAssignments(desc.Members)
+	renderGroupOffsetsTable(offsetResp.Blocks, assignments, partitions, endOffsets)
+
 	return nil
+}
+
+func (a *Admin) ListConsumerGroupLag(group string, topic string) error {
+	desc, offsetResp, partitionsByTopic, err := a.consumerGroupOffsets(group, topic)
+	if err != nil {
+		return err
+	}
+
+	partitions, endOffsets, err := a.buildGroupOffsetLookups(offsetResp.Blocks, partitionsByTopic)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "Consumer Group: %s\n", desc.GroupId)
+	fmt.Fprintln(os.Stdout)
+
+	renderGroupLagSummary(offsetResp.Blocks, partitions, endOffsets)
+
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "Partitions")
+
+	assignments := a.buildPartitionAssignments(desc.Members)
+	renderGroupOffsetsTable(offsetResp.Blocks, assignments, partitions, endOffsets)
+
+	return nil
+}
+
+func (a *Admin) consumerGroupOffsets(
+	group string,
+	topic string,
+) (*sarama.GroupDescription, *sarama.OffsetFetchResponse, topicPartitionIDs, error) {
+	desc, err := a.describeConsumerGroup(group)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	partitionsByTopic := make(topicPartitionIDs)
+
+	var requestedPartitions map[string][]int32
+
+	if topic != "" {
+		partitions, err := a.topicPartitions(topic)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		partitionsByTopic[topic] = partitions
+		requestedPartitions = partitionsByTopic
+	}
+
+	offsetResp, err := a.clusterAdmin.ListConsumerGroupOffsets(group, requestedPartitions)
+	if err != nil {
+		if errors.Is(err, sarama.ErrGroupIDNotFound) {
+			return nil, nil, nil, fmt.Errorf("%w: %s", errConsumerGroupNotFound, group)
+		}
+
+		return nil, nil, nil, fmt.Errorf("clusterAdmin.ListConsumerGroupOffsets error: %w", err)
+	}
+
+	return desc, offsetResp, partitionsByTopic, nil
+}
+
+func (a *Admin) buildGroupOffsetLookups(
+	blocks topicPartitionOffsets,
+	requestedPartitions topicPartitionIDs,
+) (topicPartitionIDs, topicPartitionEndOffsets, error) {
+	partitionsByTopic := make(topicPartitionIDs, len(blocks))
+	endOffsetsByTopic := make(topicPartitionEndOffsets, len(blocks))
+	topics := slices.SortedStableFunc(maps.Keys(blocks), cmp.Compare)
+
+	for _, topic := range topics {
+		partitions := requestedPartitions[topic]
+		if len(partitions) == 0 {
+			partitions = slices.SortedStableFunc(maps.Keys(blocks[topic]), cmp.Compare)
+		}
+
+		endOffsets, err := a.topicEndOffsets(topic, partitions)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		partitionsByTopic[topic] = partitions
+		endOffsetsByTopic[topic] = endOffsets
+	}
+
+	return partitionsByTopic, endOffsetsByTopic, nil
 }
 
 func (a *Admin) renderGroupMembersTable(members map[string]*sarama.GroupMemberDescription) error {
@@ -116,10 +209,12 @@ func (a *Admin) renderGroupMembersTable(members map[string]*sarama.GroupMemberDe
 }
 
 type (
-	topicPartitionOffsets   = map[string]map[int32]*sarama.OffsetFetchResponseBlock
-	topicPartitionOwners    = map[string]map[int32]partitionOwner
-	memberDescriptions      = map[string]*sarama.GroupMemberDescription
-	partitionOffsetResponse = map[int32]*sarama.OffsetFetchResponseBlock
+	topicPartitionOffsets    = map[string]map[int32]*sarama.OffsetFetchResponseBlock
+	topicPartitionOwners     = map[string]map[int32]partitionOwner
+	topicPartitionIDs        = map[string][]int32
+	topicPartitionEndOffsets = map[string]map[int32]int64
+	memberDescriptions       = map[string]*sarama.GroupMemberDescription
+	partitionOffsetResponse  = map[int32]*sarama.OffsetFetchResponseBlock
 )
 
 type partitionOwner struct {
@@ -153,7 +248,43 @@ func (a *Admin) buildPartitionAssignments(members memberDescriptions) topicParti
 	return assignments
 }
 
-func (a *Admin) renderGroupOffsetsTable(blocks topicPartitionOffsets, assignments topicPartitionOwners) error {
+func renderGroupLagSummary(
+	blocks topicPartitionOffsets,
+	partitionsByTopic topicPartitionIDs,
+	endOffsetsByTopic topicPartitionEndOffsets,
+) {
+	tbl := newTable()
+	tbl.Headers("Topic", "Current Offset", "Log End Offset", "Lag")
+
+	topics := slices.SortedStableFunc(maps.Keys(blocks), cmp.Compare)
+
+	for _, topic := range topics {
+		currentOffset, logEndOffset, lag, ok := summarizeOffsetsLag(
+			partitionsByTopic[topic],
+			blocks[topic],
+			endOffsetsByTopic[topic],
+		)
+		if !ok {
+			continue
+		}
+
+		tbl.Row(
+			topic,
+			strconv.FormatInt(currentOffset, 10),
+			strconv.FormatInt(logEndOffset, 10),
+			strconv.FormatInt(lag, 10),
+		)
+	}
+
+	fmt.Fprintln(os.Stdout, tbl.Render())
+}
+
+func renderGroupOffsetsTable(
+	blocks topicPartitionOffsets,
+	assignments topicPartitionOwners,
+	partitionsByTopic topicPartitionIDs,
+	endOffsetsByTopic topicPartitionEndOffsets,
+) {
 	topics := slices.SortedStableFunc(maps.Keys(blocks), cmp.Compare)
 
 	for i, topic := range topics {
@@ -163,36 +294,32 @@ func (a *Admin) renderGroupOffsetsTable(blocks topicPartitionOffsets, assignment
 
 		fmt.Fprintf(os.Stdout, "Topic: %s\n", topic)
 
-		partitions := blocks[topic]
-
-		err := a.renderTopicOffsetsTable(topic, partitions, assignments[topic])
-		if err != nil {
-			return err
-		}
+		renderTopicOffsetsTable(
+			blocks[topic],
+			partitionsByTopic[topic],
+			assignments[topic],
+			endOffsetsByTopic[topic],
+		)
 	}
-
-	return nil
 }
 
-func (a *Admin) renderTopicOffsetsTable(
-	topic string,
+func renderTopicOffsetsTable(
 	partitions partitionOffsetResponse,
+	partitionIDs []int32,
 	owners map[int32]partitionOwner,
-) error {
+	endOffsets map[int32]int64,
+) {
 	tbl := newTable()
 	tbl.Headers("Partition", "Current Offset", "Log End Offset", "Lag", "Consumer ID", "Host")
 
-	partitionIDs := slices.SortedStableFunc(maps.Keys(partitions), cmp.Compare)
-
 	for _, partitionID := range partitionIDs {
 		block := partitions[partitionID]
-
-		endOffset, err := a.client.GetOffset(topic, partitionID, sarama.OffsetNewest)
-		if err != nil {
-			return fmt.Errorf("client.GetOffset error: %w", err)
+		if block == nil || block.Offset < 0 {
+			continue
 		}
 
-		lag := endOffset - block.Offset
+		endOffset := endOffsets[partitionID]
+		lag := max(endOffset-block.Offset, 0)
 
 		var consumerID, host string
 
@@ -212,8 +339,6 @@ func (a *Admin) renderTopicOffsetsTable(
 	}
 
 	fmt.Fprintln(os.Stdout, tbl.Render())
-
-	return nil
 }
 
 var errConsumerGroupNotFound = errors.New("consumer group not found")

--- a/internal/kafka/admin/topic.go
+++ b/internal/kafka/admin/topic.go
@@ -9,9 +9,12 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"sync"
 
 	"github.com/IBM/sarama"
 )
+
+const offsetLookupConcurrency = 16
 
 func (a *Admin) ListTopicNames() ([]string, error) {
 	topicDetails, err := a.clusterAdmin.ListTopics()
@@ -204,21 +207,10 @@ func formatSize(bytes int64) string {
 }
 
 func (a *Admin) GetOffsets(topic string) error {
-	topicDetails, err := a.clusterAdmin.ListTopics()
+	partitions, err := a.topicPartitions(topic)
 	if err != nil {
-		return fmt.Errorf("clusterAdmin.ListTopics error: %w", err)
+		return err
 	}
-
-	if _, ok := topicDetails[topic]; !ok {
-		return fmt.Errorf("%w: %s", errTopicNotFound, topic)
-	}
-
-	partitions, err := a.client.Partitions(topic)
-	if err != nil {
-		return fmt.Errorf("client.Partitions error: %w", err)
-	}
-
-	slices.Sort(partitions)
 
 	tbl := newTable()
 	tbl.Headers("Partition", "Oldest Offset", "Newest Offset")
@@ -244,6 +236,108 @@ func (a *Admin) GetOffsets(topic string) error {
 	fmt.Fprintln(os.Stdout, tbl.Render())
 
 	return nil
+}
+
+func (a *Admin) topicPartitions(topic string) ([]int32, error) {
+	topicDetails, err := a.clusterAdmin.ListTopics()
+	if err != nil {
+		return nil, fmt.Errorf("clusterAdmin.ListTopics error: %w", err)
+	}
+
+	if _, ok := topicDetails[topic]; !ok {
+		return nil, fmt.Errorf("%w: %s", errTopicNotFound, topic)
+	}
+
+	partitions, err := a.client.Partitions(topic)
+	if err != nil {
+		return nil, fmt.Errorf("client.Partitions error: %w", err)
+	}
+
+	slices.Sort(partitions)
+
+	return partitions, nil
+}
+
+func (a *Admin) topicEndOffsets(topic string, partitions []int32) (map[int32]int64, error) {
+	endOffsets := make(map[int32]int64, len(partitions))
+	if len(partitions) == 0 {
+		return endOffsets, nil
+	}
+
+	jobs := make(chan int32)
+	results := make(chan offsetLookupResult, len(partitions))
+	workerCount := min(len(partitions), offsetLookupConcurrency)
+
+	var waitGroup sync.WaitGroup
+
+	for range workerCount {
+		waitGroup.Go(func() {
+			for partition := range jobs {
+				endOffset, err := a.client.GetOffset(topic, partition, sarama.OffsetNewest)
+				results <- offsetLookupResult{
+					partition: partition,
+					offset:    endOffset,
+					err:       err,
+				}
+			}
+		})
+	}
+
+	go func() {
+		for _, partition := range partitions {
+			jobs <- partition
+		}
+
+		close(jobs)
+		waitGroup.Wait()
+		close(results)
+	}()
+
+	for result := range results {
+		if result.err != nil {
+			return nil, fmt.Errorf("client.GetOffset error: %w", result.err)
+		}
+
+		endOffsets[result.partition] = result.offset
+	}
+
+	return endOffsets, nil
+}
+
+type offsetLookupResult struct {
+	partition int32
+	offset    int64
+	err       error
+}
+
+func summarizeOffsetsLag(
+	partitions []int32,
+	topicOffsets map[int32]*sarama.OffsetFetchResponseBlock,
+	endOffsets map[int32]int64,
+) (int64, int64, int64, bool) {
+	var (
+		currentOffset      int64
+		logEndOffset       int64
+		lag                int64
+		hasCommittedOffset bool
+	)
+
+	for _, partition := range partitions {
+		block, ok := topicOffsets[partition]
+		if !ok || block == nil || block.Offset < 0 {
+			continue
+		}
+
+		endOffset := endOffsets[partition]
+		partitionLag := max(endOffset-block.Offset, 0)
+
+		currentOffset += block.Offset
+		logEndOffset += endOffset
+		lag += partitionLag
+		hasCommittedOffset = true
+	}
+
+	return currentOffset, logEndOffset, lag, hasCommittedOffset
 }
 
 func (a *Admin) AlterTopicPartitions(topic string, numPartitions int32) error {

--- a/test/e2e/errors_test.go
+++ b/test/e2e/errors_test.go
@@ -151,6 +151,52 @@ clusters:
 	}
 }
 
+func TestGroupLag_NonExistentGroup(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: local
+
+clusters:
+  local:
+    brokers:
+      - 127.0.0.1:9092
+`)
+
+	WaitForKafka(t, cli)
+
+	group := UniqueGroupName(t)
+
+	_, err := cli.Run(t.Context(), "group", "lag", group)
+	if err == nil {
+		t.Error("expected error when getting lag for non-existent consumer group")
+	}
+}
+
+func TestGroupOffsets_NonExistentGroup(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: local
+
+clusters:
+  local:
+    brokers:
+      - 127.0.0.1:9092
+`)
+
+	WaitForKafka(t, cli)
+
+	group := UniqueGroupName(t)
+
+	_, err := cli.Run(t.Context(), "group", "offsets", group)
+	if err == nil {
+		t.Error("expected error when getting offsets for non-existent consumer group")
+	}
+}
+
 func TestGroupDelete_NonExistentGroup(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -223,6 +223,68 @@ func ProduceAndConsumeWithGroup(
 	}
 }
 
+func AssertGroupLagForTopic(t *testing.T, cli *KafkaCLI, group string, topic string) {
+	t.Helper()
+
+	output, err := cli.Run(t.Context(), "group", "lag", group, "--topic", topic)
+	if err != nil {
+		t.Fatalf("group lag with topic filter failed: %v", err)
+	}
+
+	if !StringsContains(output, group) {
+		t.Errorf("expected group %q in group lag output, got: %s", group, output)
+	}
+
+	if !StringsContains(output, topic) {
+		t.Errorf("expected topic %q in group lag output, got: %s", topic, output)
+	}
+
+	if !StringsContains(output, "Lag") {
+		t.Errorf("expected 'Lag' in group lag output, got: %s", output)
+	}
+
+	if !StringsContains(output, "Partitions") {
+		t.Errorf("expected 'Partitions' in group lag output, got: %s", output)
+	}
+
+	if !StringsContains(output, "Partition") {
+		t.Errorf("expected 'Partition' in group lag output, got: %s", output)
+	}
+}
+
+func AssertGroupOffsetsForTopic(t *testing.T, cli *KafkaCLI, group string, topic string) {
+	t.Helper()
+
+	output, err := cli.Run(t.Context(), "group", "offsets", group, "--topic", topic)
+	if err != nil {
+		t.Fatalf("group offsets with topic filter failed: %v", err)
+	}
+
+	if !StringsContains(output, group) {
+		t.Errorf("expected group %q in group offsets output, got: %s", group, output)
+	}
+
+	if !StringsContains(output, topic) {
+		t.Errorf("expected topic %q in group offsets output, got: %s", topic, output)
+	}
+
+	if !StringsContains(output, "Partition") {
+		t.Errorf("expected 'Partition' in group offsets output, got: %s", output)
+	}
+
+	if !StringsContains(output, "Current Offset") {
+		t.Errorf("expected 'Current Offset' in group offsets output, got: %s", output)
+	}
+
+	if !StringsContains(output, "Log End Offset") {
+		t.Errorf("expected 'Log End Offset' in group offsets output, got: %s", output)
+	}
+
+	if !StringsContains(output, "Lag") {
+		t.Errorf("expected 'Lag' in group offsets output, got: %s", output)
+	}
+}
+
 func consumeGroupErrors(ctx context.Context, client sarama.ConsumerGroup) {
 	for {
 		select {

--- a/test/e2e/plaintext_test.go
+++ b/test/e2e/plaintext_test.go
@@ -269,9 +269,42 @@ clusters:
 		t.Errorf("expected 'State:' in output, got: %s", output)
 	}
 
-	if !StringsContains(output, "Offsets") {
-		t.Errorf("expected 'Offsets' in output, got: %s", output)
+	if !StringsContains(output, "Members:") {
+		t.Errorf("expected 'Members:' in output, got: %s", output)
 	}
+}
+
+func TestGroupOffsetsAndLag_PlainText(t *testing.T) {
+	t.Parallel()
+
+	cli := NewKafkaCLI(t)
+	cli.WriteConfig(t, `
+default_cluster: local
+
+clusters:
+  local:
+    brokers:
+      - 127.0.0.1:9092
+`)
+
+	WaitForKafka(t, cli)
+
+	topic := UniqueTopicName(t)
+	group := UniqueGroupName(t)
+
+	_, err := cli.Run(t.Context(), "topic", "create", topic, "--partitions", "1", "--replication-factor", "1")
+	if err != nil {
+		t.Fatalf("create topic failed: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = cli.Run(t.Context(), "topic", "delete", topic)
+	})
+
+	ProduceAndConsumeWithGroup(t, cli, topic, group, []string{"hello-group-lag"})
+
+	AssertGroupOffsetsForTopic(t, cli, group, topic)
+	AssertGroupLagForTopic(t, cli, group, topic)
 }
 
 func TestGroupDelete_PlainText(t *testing.T) {


### PR DESCRIPTION
## Summary
- add group offsets to show committed offsets, log end offsets, and lag by partition
- update group lag to show topic-level totals plus partition details, with optional --topic filtering
- keep group describe focused on group metadata/members and optimize log end offset lookup concurrency
- remove the earlier topic consumers command and related docs/tests

## Testing
- rtk go build ./...
- rtk go test ./cmd/... ./internal/... ./test/e2e -run "^$"
- rtk just lint
- GitHub checks: Static Analysis and E2E (Kafka 4.2.0) passed