### PR TITLE
Add Kafka 4.3.1 and bump 4.2.0 to 4.2.1 in E2E tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         kafka-version:
-          - "4.2.0"
+          - "4.2.1"
+          - "4.3.1"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/test/e2e/kafka/pod-4.3.yaml
+++ b/test/e2e/kafka/pod-4.3.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kafka-ssh
+spec:
+  containers:
+  - name: ssh
+    image: docker.io/linuxserver/openssh-server:latest
+    ports:
+    - containerPort: 2222
+      hostPort: 2222
+    env:
+    - name: PUID
+      value: "1000"
+    - name: PGID
+      value: "1000"
+    - name: TZ
+      value: "UTC"
+    - name: PASSWORD_ACCESS
+      value: "false"
+    - name: USER_NAME
+      value: "kafkauser"
+    - name: PUBLIC_KEY
+      valueFrom:
+        secretKeyRef:
+          name: ssh-secrets
+          key: public-key
+    volumeMounts:
+    - name: sshd-config
+      mountPath: /config/sshd/sshd_config.d
+
+  - name: kafka-ssh-test
+    image: docker.io/apache/kafka:PLACEHOLDER_KAFKA_VERSION
+    ports:
+    - containerPort: 9092
+      hostPort: 9092
+    - containerPort: 9094
+      hostPort: 9094
+    - containerPort: 9095
+      hostPort: 9095
+    env:
+    - name: KAFKA_NODE_ID
+      value: "1"
+    - name: KAFKA_PROCESS_ROLES
+      value: "broker,controller"
+    - name: KAFKA_LISTENERS
+      value: "PLAINTEXT://0.0.0.0:9092,SASL_PLAINTEXT://0.0.0.0:9094,SSL://0.0.0.0:9095,CONTROLLER://0.0.0.0:9093"
+    - name: KAFKA_ADVERTISED_LISTENERS
+      value: "PLAINTEXT://127.0.0.1:9092,SASL_PLAINTEXT://127.0.0.1:9094,SSL://127.0.0.1:9095"
+    - name: KAFKA_CONTROLLER_LISTENER_NAMES
+      value: "CONTROLLER"
+    - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+      value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT,SSL:SSL"
+    - name: KAFKA_SASL_ENABLED_MECHANISMS
+      value: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
+    - name: KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL
+      value: "PLAIN"
+    - name: KAFKA_SSL_KEYSTORE_FILENAME
+      value: "kafka.server.keystore.jks"
+    - name: KAFKA_SSL_KEYSTORE_CREDENTIALS
+      value: "keystore_creds"
+    - name: KAFKA_SSL_KEY_CREDENTIALS
+      value: "key_creds"
+    - name: KAFKA_SSL_TRUSTSTORE_FILENAME
+      value: "kafka.server.truststore.jks"
+    - name: KAFKA_SSL_TRUSTSTORE_CREDENTIALS
+      value: "truststore_creds"
+    - name: KAFKA_SSL_CLIENT_AUTH
+      value: "none"
+    - name: KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
+      value: ""
+    - name: KAFKA_OPTS
+      value: "-Djava.security.auth.login.config=/etc/kafka/sasl/kafka_server_jaas.conf"
+    - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+      value: "1@localhost:9093"
+    - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+      value: "1"
+    - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+      value: "1"
+    - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+      value: "1"
+    - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+      value: "0"
+    volumeMounts:
+    - name: sasl-config
+      mountPath: /etc/kafka/sasl
+      readOnly: true
+    - name: tls-certs
+      mountPath: /etc/kafka/secrets
+      readOnly: true
+
+  volumes:
+  - name: sshd-config
+    hostPath:
+      path: PLACEHOLDER_SSHD_CONFIG_PATH
+      type: Directory
+  - name: sasl-config
+    hostPath:
+      path: PLACEHOLDER_SASL_CONFIG_PATH
+      type: Directory
+  - name: tls-certs
+    hostPath:
+      path: PLACEHOLDER_TLS_CERTS_PATH
+      type: Directory
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ssh-secrets
+type: Opaque
+stringData:
+  public-key: "PLACEHOLDER_SSH_PUBLIC_KEY"


### PR DESCRIPTION
Add Kafka 4.3.1 to the E2E test matrix and bump 4.2.0 to 4.2.1.

- Add `pod-4.3.yaml` pod template for the 4.3 series
- Update E2E workflow matrix: `4.2.0` → `4.2.1`, add `4.3.1`