### PR TITLE
Fix flaky topic CRUD e2e tests by polling topic list

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -473,6 +473,54 @@ func TopicExistsInOutput(output, topic string) bool {
 	return false
 }
 
+// waitForTopicListState polls `topic list` until every topic in topics is
+// present (want=true) or absent (want=false), or the deadline elapses.
+//
+// Kafka (KRaft in particular) may briefly serve a MetadataResponse that omits
+// a just-created or just-deleted topic, so topic CRUD tests must poll instead
+// of asserting on a single list call.
+func waitForTopicListState(t *testing.T, cli *KafkaCLI, want bool, topics ...string) {
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastOutput string
+
+	for {
+		output, err := cli.Run(t.Context(), "topic", "list")
+		if err != nil {
+			t.Fatalf("list topics failed: %v", err)
+		}
+
+		lastOutput = output
+
+		matched := true
+
+		for _, topic := range topics {
+			if TopicExistsInOutput(output, topic) != want {
+				matched = false
+
+				break
+			}
+		}
+
+		if matched {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			break
+		}
+
+		<-ticker.C
+	}
+
+	t.Fatalf("timed out waiting for topics %v to be present=%v in list output: %s", topics, want, lastOutput)
+}
+
 func ExtractPartitionCount(output string) string {
 	re := regexp.MustCompile(`Partitions:\s*(\d+)`)
 

--- a/test/e2e/plaintext_test.go
+++ b/test/e2e/plaintext_test.go
@@ -56,14 +56,7 @@ clusters:
 		t.Fatalf("create topic failed: %v", err)
 	}
 
-	output, err := cli.Run(t.Context(), "topic", "list")
-	if err != nil {
-		t.Fatalf("list topics failed: %v", err)
-	}
-
-	if !TopicExistsInOutput(output, topic) {
-		t.Errorf("topic %q not found in list output: %s", topic, output)
-	}
+	waitForTopicListState(t, cli, true, topic)
 
 	describeOutput, err := cli.Run(t.Context(), "topic", "describe", topic)
 	if err != nil {
@@ -80,14 +73,7 @@ clusters:
 		t.Fatalf("delete topic failed: %v", err)
 	}
 
-	output, err = cli.Run(t.Context(), "topic", "list")
-	if err != nil {
-		t.Fatalf("list topics after delete failed: %v", err)
-	}
-
-	if TopicExistsInOutput(output, topic) {
-		t.Errorf("topic %q should have been deleted but still appears in list", topic)
-	}
+	waitForTopicListState(t, cli, false, topic)
 }
 
 func TestTopicProduceConsume_PlainText(t *testing.T) {

--- a/test/e2e/produce_test.go
+++ b/test/e2e/produce_test.go
@@ -182,18 +182,7 @@ clusters:
 		t.Fatalf("delete multiple topics failed: %v", err)
 	}
 
-	output, err := cli.Run(t.Context(), "topic", "list")
-	if err != nil {
-		t.Fatalf("list topics after delete failed: %v", err)
-	}
-
-	if TopicExistsInOutput(output, topic1) {
-		t.Errorf("topic %q should have been deleted", topic1)
-	}
-
-	if TopicExistsInOutput(output, topic2) {
-		t.Errorf("topic %q should have been deleted", topic2)
-	}
+	waitForTopicListState(t, cli, false, topic1, topic2)
 }
 
 func TestGroupDelete_MultipleGroups(t *testing.T) {

--- a/test/e2e/sasl_test.go
+++ b/test/e2e/sasl_test.go
@@ -173,14 +173,7 @@ func TestTopicCRUD_SASL(t *testing.T) {
 				t.Fatalf("create topic failed: %v", err)
 			}
 
-			output, err := cli.Run(t.Context(), "topic", "list")
-			if err != nil {
-				t.Fatalf("list topics failed: %v", err)
-			}
-
-			if !TopicExistsInOutput(output, topic) {
-				t.Errorf("topic %q not found in list output: %s", topic, output)
-			}
+			waitForTopicListState(t, cli, true, topic)
 
 			describeOutput, err := cli.Run(t.Context(), "topic", "describe", topic)
 			if err != nil {
@@ -197,14 +190,7 @@ func TestTopicCRUD_SASL(t *testing.T) {
 				t.Fatalf("delete topic failed: %v", err)
 			}
 
-			output, err = cli.Run(t.Context(), "topic", "list")
-			if err != nil {
-				t.Fatalf("list topics after delete failed: %v", err)
-			}
-
-			if TopicExistsInOutput(output, topic) {
-				t.Errorf("topic %q should have been deleted but still appears in list", topic)
-			}
+			waitForTopicListState(t, cli, false, topic)
 		})
 	}
 }

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -74,14 +74,7 @@ func TestTopicCRUD_TLS(t *testing.T) {
 		t.Fatalf("create topic failed: %v", err)
 	}
 
-	output, err := cli.Run(t.Context(), "topic", "list")
-	if err != nil {
-		t.Fatalf("list topics failed: %v", err)
-	}
-
-	if !TopicExistsInOutput(output, topic) {
-		t.Errorf("topic %q not found in list output: %s", topic, output)
-	}
+	waitForTopicListState(t, cli, true, topic)
 
 	describeOutput, err := cli.Run(t.Context(), "topic", "describe", topic)
 	if err != nil {
@@ -98,14 +91,7 @@ func TestTopicCRUD_TLS(t *testing.T) {
 		t.Fatalf("delete topic failed: %v", err)
 	}
 
-	output, err = cli.Run(t.Context(), "topic", "list")
-	if err != nil {
-		t.Fatalf("list topics after delete failed: %v", err)
-	}
-
-	if TopicExistsInOutput(output, topic) {
-		t.Errorf("topic %q should have been deleted but still appears in list", topic)
-	}
+	waitForTopicListState(t, cli, false, topic)
 }
 
 func TestTopicProduceConsume_TLS(t *testing.T) {


### PR DESCRIPTION
## Problem

`E2E (Kafka 4.3.1)` has been failing intermittently (on this Dependabot sarama bump PR #38 and also on `master` after #37 merged) with:

```
tls_test.go:83: topic "e2e-test-TestTopicCRUD_TLS-..." not found in list output
--- FAIL: TestTopicCRUD_TLS
```

The `topic create` succeeds (server logs confirm the partition logs are created), but the immediately following `topic list` returns a near-empty `MetadataResponse` (only `__consumer_offsets` + one other topic), so the just-created topic is missing.

This is **not** caused by the sarama 1.60.0 -> 1.60.1 bump: the identical failure (same test, same `Total topics: 2` list output) reproduces on `master` with sarama 1.60.0 (run 30427456506). It is a metadata-consistency race against Kafka 4.3.1 (KRaft), where a broker may briefly serve a stale `MetadataResponse` right after a topic is created or deleted.

## Fix

The CRUD tests asserted on a single `topic list` call right after `create`/`delete`. Replace those one-shot assertions with a shared `waitForTopicListState` helper that polls `topic list` (200ms interval, 15s deadline) until the expected topics are present/absent.

Applied to the tests that share this create/delete -> list pattern:
- `TestTopicCRUD_TLS`
- `TestTopicCRUD_PlainText`
- `TestTopicCRUD_SASL`
- `TestTopicDelete_MultipleTopics`
